### PR TITLE
Small improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /Debug/
 /Release/
 .idea/
+.vs

--- a/de4dot-x64/Program.cs
+++ b/de4dot-x64/Program.cs
@@ -17,10 +17,22 @@
     along with de4dot.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
+
 namespace de4dot_x64 {
 	class Program {
 		static int Main(string[] args) {
-			return de4dot.cui.Program.Main(args);
+            int returnValue = 0;
+            try
+            {
+                returnValue = de4dot.cui.Program.Main(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return returnValue;
 		}
 	}
 }

--- a/de4dot/Program.cs
+++ b/de4dot/Program.cs
@@ -17,10 +17,23 @@
     along with de4dot.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
+
 namespace de4dot_x86 {
 	class Program {
-		static int Main(string[] args) {
-			return de4dot.cui.Program.Main(args);
-		}
+		static int Main(string[] args)
+        {
+            int returnValue = 0;
+            try
+            {
+                returnValue = de4dot.cui.Program.Main(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return returnValue;
+        }
 	}
 }


### PR DESCRIPTION
1. ignore the .vs folder 
2. add try catch to avoid program crash

> Application: de4dot.exe
> Framework Version: v4.0.30319
> Description: The process was terminated due to an unhandled exception.
> Exception Info: System.IO.IOException
>    at dnlib.IO.MemoryMappedFileStreamCreator+Windows.Mmap(dnlib.IO.MemoryMappedFileStreamCreator, Boolean)
>    at dnlib.IO.MemoryMappedFileStreamCreator.CreateWindows(System.String, Boolean)
>    at dnlib.IO.ImageStreamCreator.CreateMemoryMappedFileStreamCreator(System.String, Boolean)
>    at dnlib.IO.ImageStreamCreator.Create(System.String, Boolean)
>    at dnlib.PE.PEImage..ctor(System.String, Boolean, Boolean)
>    at dnlib.DotNet.MD.MetaDataCreator.Load(System.String)
>    at de4dot.code.ObfuscatedFile.LoadModule(System.Collections.Generic.IEnumerable`1<de4dot.code.deobfuscators.IDeobfuscator>)
>    at de4dot.code.ObfuscatedFile.Load(System.Collections.Generic.IList`1<de4dot.code.deobfuscators.IDeobfuscator>)
>    at de4dot.cui.FilesDeobfuscator+DotNetFileLoader.Add(de4dot.code.IObfuscatedFile, Boolean, Boolean)
>    at de4dot.cui.FilesDeobfuscator+DotNetFileLoader+<Load>d__5.MoveNext()
>    at de4dot.cui.FilesDeobfuscator+<LoadAllFiles>d__11.MoveNext()
>    at System.Collections.Generic.List`1[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]..ctor(System.Collections.Generic.IEnumerable`1<System.__Canon>)
>    at de4dot.cui.FilesDeobfuscator.DeobfuscateAll()
>    at de4dot.cui.FilesDeobfuscator.DoIt()
>    at de4dot.cui.Program.Main(System.String[])
>    at de4dot_x86.Program.Main(System.String[])
> 